### PR TITLE
Changed the gemspec to force use of aws-sdk version < 2

### DIFF
--- a/launcher.gemspec
+++ b/launcher.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "thor"
-  spec.add_dependency "aws-sdk"
+  spec.add_dependency "aws-sdk", "< 2.0"
   spec.add_dependency "colored"
   spec.add_dependency "terminal-table"
 


### PR DESCRIPTION
aws-sdk Gem >= 2 is incompatible with this Gem. As such I propose enforcing using the latest version of aws-sdk version 1 by changing the gemspec.
